### PR TITLE
Add intellij-gno

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ _Tools useful for developing in Gno._
 - [gno-mcp](https://github.com/gnoverse/gno-mcp) - An MCP server and agent skill connecting realms to AI coding assistants like Claude, Cursor, and Gemini CLI.
 - [gnobro](https://github.com/gnolang/gno/tree/master/contribs/gnobro) - A terminal UI for browsing and exploring Gno realms, with real-time gnodev integration via WebSocket.
 - [gnovanity](https://github.com/gnoverse/gnovanity) - A command-line tool for generating vanity wallet addresses.
+- [intellij-gno](https://github.com/gnoverse/intellij-gno) - A JetBrains IntelliJ plugin with editor support and syntax highlighting.
 
 ## Tutorials, Presentations, Resources
 


### PR DESCRIPTION
Adds [`gnoverse/intellij-gno`](https://github.com/gnoverse/intellij-gno) to the **Tools** section.

```markdown
- [intellij-gno](https://github.com/gnoverse/intellij-gno) - A JetBrains IntelliJ plugin with editor support and syntax highlighting.
```

Part of a batch adding gnoverse tooling + moul's gno projects (one link per PR, per CONTRIBUTING.md). Best merged after #73 (the awesome-lint + link-check CI / README cleanup); a rebase on the updated `main` will be needed to pick up the lint-clean base.
