### PR TITLE
Add tm2-indexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ _Tools useful for developing in Gno._
 - [gno-mcp](https://github.com/gnoverse/gno-mcp) - An MCP server and agent skill connecting realms to AI coding assistants like Claude, Cursor, and Gemini CLI.
 - [gnobro](https://github.com/gnolang/gno/tree/master/contribs/gnobro) - A terminal UI for browsing and exploring Gno realms, with real-time gnodev integration via WebSocket.
 - [gnovanity](https://github.com/gnoverse/gnovanity) - A command-line tool for generating vanity wallet addresses.
+- [tm2-indexer](https://github.com/gnoverse/tm2-indexer) - A Tendermint2 PostgreSQL indexer bundled with a Grafana dashboard.
 
 ## Tutorials, Presentations, Resources
 


### PR DESCRIPTION
Adds [`gnoverse/tm2-indexer`](https://github.com/gnoverse/tm2-indexer) to the **Tools** section.

```markdown
- [tm2-indexer](https://github.com/gnoverse/tm2-indexer) - A Tendermint2 PostgreSQL indexer bundled with a Grafana dashboard.
```

Part of a batch adding gnoverse tooling + moul's gno projects (one link per PR, per CONTRIBUTING.md). Best merged after #73 (the awesome-lint + link-check CI / README cleanup); a rebase on the updated `main` will be needed to pick up the lint-clean base.
