### PR TITLE
Add safeurl-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ _Connecting web2 to the gno.land blockchain._
 - [tm2-js-client](https://github.com/gnolang/tm2-js-client) - A TM2 JavaScript client library.
 - [gno-js-client](https://github.com/gnolang/gno-js-client) - A Gno JavaScript client library, built upon `tm2-js` with additional Gno-specific functionality.
 - [gnonative](https://github.com/gnolang/gnonative) - A framework for building and porting gno.land dApps in your native language, with React Native and Expo support.
+- [safeurl-sdk](https://github.com/gnoverse/safeurl-sdk) - The client SDK for the SafeURL screening service.
 
 ## Frameworks
 


### PR DESCRIPTION
Adds [`gnoverse/safeurl-sdk`](https://github.com/gnoverse/safeurl-sdk) to the **SDKs & Clients** section.

```markdown
- [safeurl-sdk](https://github.com/gnoverse/safeurl-sdk) - The client SDK for the SafeURL screening service.
```

Part of a batch adding gnoverse tooling + moul's gno projects (one link per PR, per CONTRIBUTING.md). Best merged after #73 (the awesome-lint + link-check CI / README cleanup); a rebase on the updated `main` will be needed to pick up the lint-clean base.
