### PR TITLE
Add GovDAO Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ _Apps developed by the gno.land team._
 - [Gno Faucet Hub](https://faucet.gno.land) - A central place for all gno.land faucets.
 - [Is gno.land down?](https://status.gnoteam.com) - A dashboard showing the status of gno.land services & networks.
 - [OpenOcean](https://github.com/Molaryy/openocean) - OpenSea Clone in Gno.
+- [GovDAO Web](https://govdao.gnoteam.com/) - A web UI for viewing and voting on on-chain governance proposals.
 
 ## Community Apps
 


### PR DESCRIPTION
Adds [`gnoverse/govdao-web`](https://github.com/gnoverse/govdao-web) to the **Apps** section.

```markdown
- [GovDAO Web](https://github.com/gnoverse/govdao-web) - A web UI for viewing and voting on on-chain governance proposals.
```

Part of a batch adding gnoverse tooling + moul's gno projects (one link per PR, per CONTRIBUTING.md). Best merged after #73 (the awesome-lint + link-check CI / README cleanup); a rebase on the updated `main` will be needed to pick up the lint-clean base.
