### PR TITLE
Add Boards2 Mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ _Apps developed by the gno.land team._
 - [Gno Faucet Hub](https://faucet.gno.land) - A central place for all gno.land faucets.
 - [Is gno.land down?](https://status.gnoteam.com) - A dashboard showing the status of gno.land services & networks.
 - [OpenOcean](https://github.com/Molaryy/openocean) - OpenSea Clone in Gno.
+- [Boards2 Mobile](https://github.com/gnoverse/boards2-mobile) - An experimental mobile client for the on-chain boards realm.
 
 ## Community Apps
 


### PR DESCRIPTION
Adds [`gnoverse/boards2-mobile`](https://github.com/gnoverse/boards2-mobile) to the **Apps** section.

```markdown
- [Boards2 Mobile](https://github.com/gnoverse/boards2-mobile) - An experimental mobile client for the on-chain boards realm.
```

Part of a batch adding gnoverse tooling + moul's gno projects (one link per PR, per CONTRIBUTING.md). Best merged after #73 (the awesome-lint + link-check CI / README cleanup); a rebase on the updated `main` will be needed to pick up the lint-clean base.
