### PR TITLE
Add Volos

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ _Apps developed by the gno.land community._
 - [Gnolove](https://gnolove.world) - Community leaderboard and contributions analytics for builders of the Gnoland ecosystem.
 - [Zenao](https://zenao.io) - Organize events in seconds then build your resilient community & social organizations.
 - [Gnomputer](https://github.com/moul/gnomputer) - A windowed web workstation for browsing realms, source, and live chain activity.
+- [Volos](https://github.com/gnoverse/volos) - The first lending protocol built on gno.land.
 
 ## Tools
 


### PR DESCRIPTION
Adds [`gnoverse/volos`](https://github.com/gnoverse/volos) to the **Community Apps** section.

```markdown
- [Volos](https://github.com/gnoverse/volos) - The first lending protocol built on gno.land.
```

Part of a batch adding gnoverse tooling + moul's gno projects (one link per PR, per CONTRIBUTING.md). Best merged after #73 (the awesome-lint + link-check CI / README cleanup); a rebase on the updated `main` will be needed to pick up the lint-clean base.
