### PR TITLE
Add Game of Life

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ _Apps developed by the gno.land community._
 - [Gnolove](https://gnolove.world) - Community leaderboard and contributions analytics for builders of the Gnoland ecosystem.
 - [Zenao](https://zenao.io) - Organize events in seconds then build your resilient community & social organizations.
 - [Gnomputer](https://github.com/moul/gnomputer) - A windowed web workstation for browsing realms, source, and live chain activity.
+- [Game of Life](https://github.com/gnoverse/game-of-life) - A cellular-automaton simulation with an on-chain smart-contract backend.
 
 ## Tools
 


### PR DESCRIPTION
Adds [`gnoverse/game-of-life`](https://github.com/gnoverse/game-of-life) to the **Community Apps** section.

```markdown
- [Game of Life](https://github.com/gnoverse/game-of-life) - A cellular-automaton simulation with an on-chain smart-contract backend.
```

Part of a batch adding gnoverse tooling + moul's gno projects (one link per PR, per CONTRIBUTING.md). Best merged after #73 (the awesome-lint + link-check CI / README cleanup); a rebase on the updated `main` will be needed to pick up the lint-clean base.
